### PR TITLE
Enable extension support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nvidia/cuda:12.3.2-runtime-ubuntu22.04
 LABEL org.opencontainers.image.source https://github.com/Yummiii/sd-webui-forge-docker
 WORKDIR /app
 RUN apt update && apt upgrade -y
-RUN apt install -y wget git python3 python3-venv libgl1 libglib2.0-0 apt-transport-https libgoogle-perftools-dev bc
+RUN apt install -y wget git python3 python3-venv libgl1 libglib2.0-0 apt-transport-https libgoogle-perftools-dev bc python3-pip
 
 COPY run.sh /app/run.sh
 RUN chmod +x /app/run.sh

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ services:
     ports:
       - "7860:7860"
     environment:
-      - "ARGS=--listen"
+      - "ARGS=--listen --enable-insecure-extension-access" # Insecure extension access is required if you want to install extensions with the listen flag
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "7860:7860"
     environment:
-      - "ARGS=--listen"
+      - "ARGS=--listen --enable-insecure-extension-access"
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
This adds the `enable-secure-extensions` flag which is required to install extensions since you're using the `listen` flag.

Additionally it adds `pip` which is required by many extensions to install dependencies.